### PR TITLE
add short section on definitions

### DIFF
--- a/paper.qmd
+++ b/paper.qmd
@@ -55,12 +55,11 @@ We will use the simple feature access standards definitions of geometric primiti
 
 The objective of this algorithm is to identify matches between two LineString FeatureCollections and measure the length of the match. A **match** is a correspondence between features of separate FeatureCollections (@lei_lei_19).
 
-The terminology to refer to the two FeatureCollections is inconsistent. For example, Zhang (@zhang_2009) refers to the two FeatureCollections as the **reference** and **target** whereas the Java Conflation Suite (JCS) (@jcs) refers to these as the **reference** and **subject**. 
+The terminology to refer to the two FeatureCollections is inconsistent in the literature. For example, Zhang (@zhang_2009) refers to the two FeatureCollections as the reference and target whereas the Java Conflation Suite (JCS) (@jcs) refers to these as the reference and subject. 
 
-We will use the terms _reference_ FeatureCollection and _subject_ FeatureCollection. The objective of the matching algorithm is to match features _from_ the subject _to_ the reference. Often the reference is a more detailed and known collection of features.
+We intentionally lean on terminology used in relational database management systems (RDBMS), instead recognizing a shift towards spatial data science which incorporates RDBMS tools. We define the two FeatureCollections as **target** and the **source**. The objective of the matching algorithm is to match features _from_ the source _to_ the target. Often the target is a more detailed and known collection of features.
 
-In the process matching features, **candidate**s are found. A candidate is a subject feature that may correspond to a reference feature. If a candidate passes tests, it is then deemed a match. After matches have been found, attributes from the source feature are often transferred to the reference feature. This process of attribute transfer is referred to as **integration**. 
-
+In the process matching features, **candidate**s are found. A candidate is a source feature that _may_ correspond to a target feature. If a candidate passes tests, it is then deemed a match. After matches have been found, attributes from the source feature are often transferred to the target feature. This process of attribute transfer is referred to as **integration**. 
 
 ## Existing algorithms 
 
@@ -343,6 +342,9 @@ If $\theta_{A_{ik}} \le 45^{\circ}$, we calculate the overlap between the range 
 - ^ related to above, we need to document the cardinality of our approach one-to-many there is no 1:1 matching of linestrings (Lei, Ting; Lei, Zhen (2019).)
  - > Beyond the one‐to‐one case, however, matching becomes more complicated and less well‐defined.
  
+ 
+- a feature in the source and target may only be matched a maximum of once. 
+- the shared length between i and j may exceeed the total length of i or j. This occurs in parallel ways and larger distance tolerances
  
  
 ### References

--- a/paper.qmd
+++ b/paper.qmd
@@ -20,9 +20,6 @@ knitr::opts_chunk$set(echo = FALSE)
 
 ## Abstract 
 
-
-
-
 Reconciling topologically different linestrings is a fundamental challenge in spatial data science, particularly when attempting to integrate network datasets from disparate sources. Existing methods often struggle with the absence of join keys and the need for wholesale joining of attributes, hindering effective data integration and analysis. In this paper, we propose a novel algorithm for matching two sets of linestrings, implemented in an open-source Rust library with bindings to R and Python. Our algorithm addresses the challenge by identifying topologically similar linestrings and estimating the shared length between each pair of matched linestrings. By leveraging R* spatial indices and angle-based matching criteria, our approach effectively reconciles linestrings with varying topologies. We demonstrate the utility of our algorithm through applications in spatial data analysis, including joins, weighted aggregations, and network subset identification based on shared characteristics. The proposed algorithm offers a robust solution for reconciling linestrings in spatial datasets, with implications for various domains in spatial data science.
 
 
@@ -49,6 +46,20 @@ Reconciling topologically different linestrings is a fundamental challenge in sp
 - in this paper we introduce a method of spatial interpolation of linear features
 
 > "Due to the complexity and limitations of existing methods, planners and analysts often have to employ a heavily manual conflation process, which is time‐consuming and often prohibitively expensive." Lei, Ting; Lei, Zhen (2019).
+
+## Definitions
+
+The purpose of this section is to provide clear and concise definitions of terminologies used in the description of this algorithm. 
+
+We will use the simple feature access standards definitions of geometric primitives for the sake of consistency. In our algorithm we make extensive use of **Line** and **LineString** geometric primitives. A Line is defined by two **Point**s that are (x, y) coordinate pairs. A LineString is composed of 2 or more Points and "each consecutive pair of Points defines a Line segment." (@sfa FIXME cite). Each LineString is referred to as a **feature**. An array of features is referred to as a **FeatureCollection** (@geojson_spec). 
+
+The objective of this algorithm is to identify matches between two LineString FeatureCollections and measure the length of the match. A **match** is a correspondence between features of separate FeatureCollections (@lei_lei_19).
+
+The terminology to refer to the two FeatureCollections is inconsistent. For example, Zhang (@zhang_2009) refers to the two FeatureCollections as the **reference** and **target** whereas the Java Conflation Suite (JCS) (@jcs) refers to these as the **reference** and **subject**. 
+
+We will use the terms _reference_ FeatureCollection and _subject_ FeatureCollection. The objective of the matching algorithm is to match features _from_ the subject _to_ the reference. Often the reference is a more detailed and known collection of features.
+
+In the process matching features, **candidate**s are found. A candidate is a subject feature that may correspond to a reference feature. If a candidate passes tests, it is then deemed a match. After matches have been found, attributes from the source feature are often transferred to the reference feature. This process of attribute transfer is referred to as **integration**. 
 
 
 ## Existing algorithms 


### PR DESCRIPTION
PR adds a brief section to paper.qmd to provide clear and concise defintions. 

@Robinlovelace do these definitions make sense to you? I considered add my folder of papers to this PR so they can be centralized but was concerned it would be annoying let me know. 

If you agree on the definitions, I propose that I go back and amend the Rust and R code to use `reference` and `subject` instead of `x` and `y` for the sake of clarity and consistency. Right now the R functions use `x` and `y` whereas the pseudo code uses `A` and `B`. Having clarity in parameters is going to help clarify the rest (for me at least). 

I know you want the code, but I feel that without a good written description and definition we don't have a clear objective which is why I'm focusing on writing this out. It's like really helpful scope definition for me. 